### PR TITLE
Add es6-shim to dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/sentenai/js-sentenai/issues"
   },
-  "homepage": "https://github.com/sentenai/js-sentenai#readme"
+  "homepage": "https://github.com/sentenai/js-sentenai#readme",
+  "dependencies": {
+    "es6-shim": "0.35.3"
+  }
 }


### PR DESCRIPTION
It was missing, resulting in `Error: Cannot find module 'es6-shim'`