### PR TITLE
fix start/end, fix nested And/Or, listing multiple conditions is shorthand for And

### DIFF
--- a/src/flare.js
+++ b/src/flare.js
@@ -208,7 +208,11 @@ class Width {
 
 class And {
   constructor (conds) {
-    this.conds = conds;
+    if (conds.length > 2) {
+      this.conds = [conds[0], new And(conds.slice(1))];
+    } else {
+      this.conds = conds;
+    }
   }
   get ast () {
     return {
@@ -224,8 +228,12 @@ class And {
 }
 
 class Or {
-  constructor (alternatives) {
-    this.conds = alternatives;
+  constructor (conds) {
+    if (conds.length > 2) {
+      this.conds = [conds[0], new Or(conds.slice(1))];
+    } else {
+      this.conds = conds;
+    }
   }
   get ast () {
     return {

--- a/src/flare.js
+++ b/src/flare.js
@@ -43,14 +43,15 @@ class Select {
   }
 
   get ast () {
-    var c = {'select': this.serial.ast};
-    if (this.start) {
-      c['start'] = this.start;
+    var ast = {'select': this.serial.ast};
+    if (this.start && this.end) {
+      ast.between = [this.start, this.end];
+    } else if (this.start) {
+      ast.after = this.start;
+    } else if (this.end) {
+      ast.before = this.end;
     }
-    if (this.end) {
-      c['end'] = this.end;
-    }
-    return c;
+    return ast;
   }
 }
 
@@ -327,14 +328,16 @@ class BoundSwitch {
 
 var Flare = {};
 
-Flare.select = function (start, end) {
+Flare.select = function (options) {
+  options || (options = {});
+
   return function () {
     if (arguments.length === 0) {
       throw FlareException('select * not supported yet');
     } else if (arguments.length === 1) {
-      return new Select(arguments[0], start, end);
+      return new Select(arguments[0], options.start, options.end);
     } else {
-      return new Select(new And(Array.from(arguments)), start, end);
+      return new Select(new And(Array.from(arguments)), options.start, options.end);
     }
   };
 };

--- a/src/flare.js
+++ b/src/flare.js
@@ -334,7 +334,7 @@ Flare.select = function (start, end) {
     } else if (arguments.length === 1) {
       return new Select(arguments[0], start, end);
     } else {
-      return new Select(new Serial(Array.from(arguments)), start, end);
+      return new Select(new And(Array.from(arguments)), start, end);
     }
   };
 };

--- a/src/flare.test.js
+++ b/src/flare.test.js
@@ -361,3 +361,22 @@ test('or stream filters', () => {
     }
   });
 });
+
+test('multiple conditions is shorthand for &&', () => {
+  const s = stream('S');
+  const t = stream('T');
+
+  expectAST(
+    select()(
+      s({ sunny: true }),
+      t({ happy: true })
+    )
+  ).toEqual(
+    select()(
+      and(
+        s({ sunny: true }),
+        t({ happy: true })
+      )
+    ).ast
+  );
+});

--- a/src/flare.test.js
+++ b/src/flare.test.js
@@ -380,3 +380,37 @@ test('multiple conditions is shorthand for &&', () => {
     ).ast
   );
 });
+
+test('specifying start and end', () => {
+  const s = stream('S');
+
+  const cond = s({ sunny: true });
+  const base = cond.ast;
+
+  const start = '2017-06-01T00:00:00+00:00';
+  const end = '2017-06-12T00:00:00+00:00';
+
+  expectAST(
+    select({ start, end })(cond)
+  ).toEqual({
+    between: [
+      start,
+      end
+    ],
+    select: base
+  });
+
+  expectAST(
+    select({ start })(cond)
+  ).toEqual({
+    after: start,
+    select: base
+  });
+
+  expectAST(
+    select({ end })(cond)
+  ).toEqual({
+    before: end,
+    select: base
+  });
+});


### PR DESCRIPTION
* `start`/`end` wasn't properly applied to the AST. also, it's now specified in an `options` argument, almost like named params.

```js
// before
select(start, end)(...)
// now
select({ start, end })(...)

// before
select(undefined, end)(...)
// now
select({ end })(...)
```

* `And`/`Or` was producing

```js
{ "expr": "&&",
"args": [{}, {}, {}] }
```

but `args` can only be length 2. now it'll properly nest

```js
{ "expr": "&&",
  "args": [ 
    {}, 
    { "expr": "&&", args: [{}, {}] } 
  ] 
}
```

* listing multiple conditions in a `select` was producing a `serial`, but now it produces an `&&` like the python lib